### PR TITLE
Add OpenSUSE Tumbleweed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
   # against glibc's struct layouts and crash on musl before this project's own code even runs.
   # Clang's compiler-rt is the sanitizer runtime Alpine's own ecosystem actually maintains musl
   # support for, so the sanitizer variant uses Clang exclusively.
-  build-test:
+  build-test-alpine:
     name: build-and-test (alpine, ${{ matrix.id }})
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,14 +252,34 @@ jobs:
   # openSUSE Tumbleweed's rolling repos ship gRPC/Protobuf/Abseil/spdlog/gflags/gtest/glaze as a
   # single version-matched, tested-together bundle (unlike Alpine/Debian/Fedora, where these
   # versions are not necessarily coordinated), so this job is a second, independent system-package
-  # sanity check alongside the Alpine job above - GCC only, no sanitizers, matching Alpine's
-  # gcc-debug baseline.
+  # sanity check alongside the Alpine job above.
+  #
+  # Unlike Alpine, the sanitizer variant here uses GCC, not Clang: Tumbleweed is glibc-based, so
+  # GCC's libsanitizer interceptors (built and tested against glibc) work natively - none of the
+  # musl incompatibility that forces Alpine's sanitizer job onto Clang applies here. GCC's sanitizer
+  # runtime also symbolizes via addr2line/binutils directly, no separate llvm-symbolizer needed.
   build-test-opensuse:
-    name: build-and-test (opensuse-tumbleweed, gcc-debug)
+    name: build-and-test (opensuse-tumbleweed, ${{ matrix.id }})
     runs-on: ubuntu-latest
     container:
       image: opensuse/tumbleweed:latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: gcc-debug
+            cxx_flags: ""
+            linker_flags: ""
+            asan_options: ""
+          # Same ASan runtime options as the Alpine clang-asan-ubsan variant - see ci.yml history
+          # for the rationale behind each one.
+          - id: gcc-asan-ubsan
+            cxx_flags: "-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer"
+            linker_flags: "-fsanitize=address,undefined"
+            asan_options: >-
+              detect_invalid_pointer_pairs=2 quarantine_size_mb=512 strict_string_checks=1
+              detect_stack_use_after_return=1 detect_leaks=1 check_initialization_order=1 strict_init_order=1
     steps:
       - name: Install build dependencies
         run: |
@@ -293,10 +313,15 @@ jobs:
           rm -rf /tmp/EventLoop
 
       - name: Configure
-        run: cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++
+        run: |
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++ \
+            -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" \
+            -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.linker_flags }}"
 
       - name: Build
         run: cmake --build build
 
       - name: Test
+        env:
+          ASAN_OPTIONS: ${{ matrix.asan_options }}
         run: ctest --test-dir build --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,3 +248,55 @@ jobs:
                 },
               });
             }
+
+  # openSUSE Tumbleweed's rolling repos ship gRPC/Protobuf/Abseil/spdlog/gflags/gtest/glaze as a
+  # single version-matched, tested-together bundle (unlike Alpine/Debian/Fedora, where these
+  # versions are not necessarily coordinated), so this job is a second, independent system-package
+  # sanity check alongside the Alpine job above - GCC only, no sanitizers, matching Alpine's
+  # gcc-debug baseline.
+  build-test-opensuse:
+    name: build-and-test (opensuse-tumbleweed, gcc-debug)
+    runs-on: ubuntu-latest
+    container:
+      image: opensuse/tumbleweed:latest
+    timeout-minutes: 10
+    steps:
+      - name: Install build dependencies
+        run: |
+          zypper --non-interactive --gpg-auto-import-keys refresh
+          zypper --non-interactive install \
+            cmake ninja git gcc-c++ \
+            grpc-devel \
+            protobuf-devel \
+            abseil-cpp-devel \
+            c-ares-devel \
+            re2-devel \
+            libopenssl-devel \
+            zlib-devel \
+            spdlog-devel \
+            gflags-devel \
+            gtest \
+            glaze-devel
+
+      - uses: actions/checkout@v5
+
+      # See the comment on the Alpine job's EventLoop step - same fork pin, same reason.
+      - name: Build and install EventLoop
+        run: |
+          git clone https://github.com/anderewrey/EventLoop.git /tmp/EventLoop
+          cd /tmp/EventLoop
+          git checkout d5d29a0349f3159067df0c3ff2741f1e984679f0
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+            -DCMAKE_CXX_COMPILER=g++
+          cmake --build build
+          cmake --install build
+          rm -rf /tmp/EventLoop
+
+      - name: Configure
+        run: cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure

--- a/applications/reactor/tests/CMakeLists.txt
+++ b/applications/reactor/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Reactor Client Tests
 
-find_package(GTest CONFIG REQUIRED)
+find_package(GTest REQUIRED)
 find_package(EventLoop CONFIG REQUIRED)
 
 set(REACTOR_TESTS

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -109,7 +109,7 @@ port) to avoid conflicts between parallel test runs.
 
 ## Continuous integration
 
-[ci.yml][ci-workflow] runs the test suite as a `build-test` job with three matrix variants, each an
+[ci.yml][ci-workflow] runs the test suite as a `build-test-alpine` job with three matrix variants, each an
 Alpine container with a different compiler and sanitizer combination, plus a separate lint job.
 `fail-fast` is disabled, so a failure in one variant does not block the others from reporting their
 own result. Each variant installs its own apk packages and rebuilds EventLoop from source


### PR DESCRIPTION
- Adds a second system-package sanity-check job, `build-test-opensuse`, running on `opensuse/tumbleweed:latest` alongside the existing Alpine job — two variants: `gcc-debug` and `gcc-asan-ubsan`.
- Tumbleweed's rolling repos ship gRPC, Protobuf, Abseil, spdlog, gflags, gtest, and glaze as a single version-matched bundle that openSUSE builds and tests together, unlike Alpine/Debian/Fedora where these versions aren't necessarily coordinated.
- Unlike Alpine, the sanitizer variant here uses **GCC**, not Clang: Tumbleweed is glibc-based, so GCC's libsanitizer interceptors work natively - none of the musl incompatibility that forces Alpine's sanitizer job onto Clang applies here.
- Fixes `find_package(GTest CONFIG REQUIRED)` → `find_package(GTest REQUIRED)` in `applications/reactor/tests/CMakeLists.txt`: openSUSE's `gtest` package ships only headers, `.so` files, and pkg-config files - no CMake package config. CMake's built-in `FindGTest` module handles both cases (delegates to a config file when one exists, falls back to classic header/library discovery otherwise), so vcpkg and Alpine are unaffected.
- Renames the Alpine job's YAML key from `build-test` to `build-test-alpine` for consistency now that `build-test-opensuse` exists alongside it (display name was already `build-and-test (alpine, ...)`; only the internal job id changes - no impact on required-check names).
