### PR TITLE
Build EventLoop via vcpkg in CI, drop the hand-rolled clone/build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install build dependencies
         run: |
           apk add --no-cache \
-            cmake ninja git ${{ matrix.packages }} \
+            cmake ninja git curl zip unzip tar ${{ matrix.packages }} \
             protobuf-dev \
             grpc-dev \
             abseil-cpp-dev \
@@ -123,21 +123,22 @@ jobs:
 
       - uses: actions/checkout@v5
 
-      # Pinned to a commit on the anderewrey/EventLoop fork's cmake-improvement branch, not
-      # upstream amoldhamale1105/EventLoop, since that branch carries fixes this project needs
-      # (LANGUAGES CXX restriction, install() rules, GNUInstallDirs) that are proposed upstream but
-      # not yet merged - see TODOS.md. No patches needed here - the fork commit already has them
-      # applied directly. Revert to upstream + the two patch files once the PR is accepted.
-      - name: Build and install EventLoop
+      # -musl selects vcpkg-tool's musl build, since Alpine is not glibc-based.
+      # VCPKG_FORCE_SYSTEM_BINARIES=1 makes it using the apk-installed cmake/ninja.
+      - name: Build and install EventLoop via vcpkg
+        env:
+          VCPKG_FORCE_SYSTEM_BINARIES: "1"
         run: |
-          git clone https://github.com/anderewrey/EventLoop.git /tmp/EventLoop
-          cd /tmp/EventLoop
-          git checkout d5d29a0349f3159067df0c3ff2741f1e984679f0
-          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-            -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }}
-          cmake --build build
-          cmake --install build
-          rm -rf /tmp/EventLoop
+          git clone --depth 1 https://github.com/microsoft/vcpkg.git /tmp/vcpkg
+          /tmp/vcpkg/bootstrap-vcpkg.sh -musl -disableMetrics
+          case "${{ matrix.cxx_compiler }}" in
+            clang++) triplet=x64-linux-clang-release ;;
+            *) triplet=x64-linux-gcc-release ;;
+          esac
+          /tmp/vcpkg/vcpkg install eventloop --classic --triplet="$triplet" \
+            --overlay-triplets=vcpkg/triplets --overlay-ports=vcpkg/ports
+          cp -r /tmp/vcpkg/packages/eventloop_$triplet/* /usr/local/
+          rm -rf /tmp/vcpkg
 
       - name: Configure
         run: |
@@ -284,7 +285,7 @@ jobs:
         run: |
           zypper --non-interactive --gpg-auto-import-keys refresh
           zypper --non-interactive install \
-            cmake ninja git gcc-c++ \
+            cmake ninja git gcc-c++ curl zip unzip tar \
             grpc-devel \
             protobuf-devel \
             abseil-cpp-devel \
@@ -298,17 +299,14 @@ jobs:
 
       - uses: actions/checkout@v5
 
-      # See the comment on the Alpine job's EventLoop step - same fork pin, same reason.
-      - name: Build and install EventLoop
+      - name: Build and install EventLoop via vcpkg
         run: |
-          git clone https://github.com/anderewrey/EventLoop.git /tmp/EventLoop
-          cd /tmp/EventLoop
-          git checkout d5d29a0349f3159067df0c3ff2741f1e984679f0
-          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-            -DCMAKE_CXX_COMPILER=g++
-          cmake --build build
-          cmake --install build
-          rm -rf /tmp/EventLoop
+          git clone --depth 1 https://github.com/microsoft/vcpkg.git /tmp/vcpkg
+          /tmp/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+          /tmp/vcpkg/vcpkg install eventloop --classic --triplet=x64-linux-gcc-release \
+            --overlay-triplets=vcpkg/triplets --overlay-ports=vcpkg/ports
+          cp -r /tmp/vcpkg/packages/eventloop_x64-linux-gcc-release/* /usr/local/
+          rm -rf /tmp/vcpkg
 
       - name: Configure
         run: |

--- a/vcpkg/ports/eventloop/portfile.cmake
+++ b/vcpkg/ports/eventloop/portfile.cmake
@@ -1,29 +1,20 @@
-# Pinned to a commit on the anderewrey/EventLoop fork's cmake-improvement branch, not upstream
-# amoldhamale1105/EventLoop, since that branch carries the LANGUAGES CXX restriction, install()
-# rules, and GNUInstallDirs fixes this project needs, proposed upstream but not yet merged
-# (see TODOS.md). No patches needed here - the fork commit already has the fixes applied directly.
-# Revert REPO/REF/SHA512 to upstream and drop this comment once the PR is accepted.
-
+# EventLoop has no tagged releases, so REF is pinned to a commit rather than derived from VERSION.
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO anderewrey/EventLoop
-    REF d5d29a0349f3159067df0c3ff2741f1e984679f0
-    SHA512 311f2d167d26c0afbb92b905622ceefb801be06ea6fe9f41569cc476d8eb6c10fccc9b13daae0bc86d6d2b2ffe877e251c0577d4fe5fe3b1c541641edae08c0c
+    REPO amoldhamale1105/EventLoop
+    REF e967d5e6f6856784c77e3aaa35fd39374a275723
+    SHA512 6d2b23eca3f2aeaea2425c5a4f631f8958bf2c39db18108e9308c4e8151308beb5d4d1fa9bda83c64b220ad9420cbcfc0e94c177fdcd5bd36f863fe66f9baf15
     HEAD_REF master
 )
 
-# Configure and install using CMake
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )
 
 vcpkg_cmake_install()
 
-# Fix CMake config file locations
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/EventLoop)
 
-# Remove empty directories if header-only
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# Install license
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg/ports/eventloop/vcpkg.json
+++ b/vcpkg/ports/eventloop/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "eventloop",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "description": "Minimalist event loop library - overlay port required (not in vcpkg registry)",
   "homepage": "https://github.com/amoldhamale1105/EventLoop",
   "license": "MIT",

--- a/vcpkg/ports/grpc/portfile.cmake
+++ b/vcpkg/ports/grpc/portfile.cmake
@@ -1,7 +1,8 @@
 # Custom gRPC port for grpc_reactor_routeguide project
 # Based on docs/grpc-build-guide.md specifications
-# Version: 1.73.1
 # C++ only, speed-optimized, minimal features
+
+# VERSION is injected by vcpkg from this port's own vcpkg.json "version" field.
 
 # Why we call git directly instead of using vcpkg_from_git or vcpkg_from_github:
 #
@@ -14,18 +15,18 @@
 #
 # This approach matches docs/grpc-build-guide.md: git clone --depth 1 --recurse-submodules
 
-set(SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/src/grpc-v1.73.1")
+set(SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/src/grpc-v${VERSION}")
 
 if(NOT EXISTS "${SOURCE_PATH}/.git")
     find_program(GIT git)
 
-    message(STATUS "Cloning gRPC v1.73.1 with submodules...")
+    message(STATUS "Cloning gRPC v${VERSION} with submodules...")
     file(MAKE_DIRECTORY "${CURRENT_BUILDTREES_DIR}/src")
 
     vcpkg_execute_required_process(
         COMMAND ${GIT} clone
             --depth 1
-            --branch v1.73.1
+            --branch v${VERSION}
             --recurse-submodules
             https://github.com/grpc/grpc.git
             ${SOURCE_PATH}


### PR DESCRIPTION
CI previously duplicated EventLoop's upstream repo/ref outside the vcpkg port so its distro-package-based jobs could build EventLoop from source without vcpkg. Both jobs now bootstrap vcpkg and build the same overlay port instead, so the pin only exists in one place: the port's own portfile.cmake, hardcoded per vcpkg convention (no tagged EventLoop release to derive REF from).

Also switch the custom gRPC port to vcpkg's own injected ${VERSION} instead of manually re-reading its vcpkg.json, matching how the official grpc/protobuf/fmt ports do it.