### PR TITLE
Add clang-tidy and enable cmake-lint, in their own static-analysis workflow

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ Checks: >
   misc-*,
   portability-*,
   readability-*,
+  clang-analyzer-*,
   -readability-magic-numbers,
   -readability-identifier-length,
   -misc-non-private-member-variables-in-classes,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 anderewrey
+
+# Scoped to this project's own sources - see HeaderFilterRegex below.
+Checks: >
+  -*,
+  bugprone-*,
+  performance-*,
+  misc-*,
+  portability-*,
+  readability-*,
+  -readability-magic-numbers,
+  -readability-identifier-length,
+  -misc-non-private-member-variables-in-classes,
+  -misc-include-cleaner
+# reactor_client.h's protected reactor members are intentional (see architecture.md), not a defect.
+# misc-include-cleaner is disabled: it flagged umbrella-header symbol use as 63 of 99 diagnostics.
+HeaderFilterRegex: '^(applications|rg_service|protobuf_utils|common)/'
+WarningsAsErrors: ''
+FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,5 +23,8 @@ Checks: >
 # Unanchored (no leading ^): compile_commands.json's -I paths are absolute (CMAKE_SOURCE_DIR always
 # is), so clang-tidy reports header paths as absolute too - an anchored pattern never matches them.
 HeaderFilterRegex: '.*/(applications|rg_service|protobuf_utils|common)/.*'
+# Without this, the pattern above also matches protoc's generated headers under
+# build/rg_service/generated/ (the out-of-source build directory mirrors rg_service/'s name).
+ExcludeHeaderFilterRegex: '/build/'
 WarningsAsErrors: ''
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,12 @@ Checks: >
   -misc-include-cleaner
 # reactor_client.h's protected reactor members are intentional (see architecture.md), not a defect.
 # misc-include-cleaner is disabled: it flagged umbrella-header symbol use as 63 of 99 diagnostics.
-HeaderFilterRegex: '^(applications|rg_service|protobuf_utils|common)/'
+# clang-analyzer-* and bugprone-* both target similar defect classes (e.g. use-after-free); kept as
+# occasional double-reporting, not disabled, since no concrete pair of checks is confirmed to
+# always co-fire on the same code.
+#
+# Unanchored (no leading ^): compile_commands.json's -I paths are absolute (CMAKE_SOURCE_DIR always
+# is), so clang-tidy reports header paths as absolute too - an anchored pattern never matches them.
+HeaderFilterRegex: '.*/(applications|rg_service|protobuf_utils|common)/.*'
 WarningsAsErrors: ''
 FormatStyle: none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    name: lint (pre-commit)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.x'
-      - uses: pre-commit/action@v3.0.1
-
   # Three variants of the same job, each an Alpine container with a different compiler and
   # sanitizer combination. fail-fast is off so a failure in one variant doesn't cancel the others -
   # they are pass/fail gates (a failure needs ctest's raw output/stack trace, not a table), except

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -25,7 +25,9 @@ jobs:
           python-version: '3.x'
       - uses: pre-commit/action@v3.0.1
 
-  # Kept separate from ci.yml so it runs on every push without the whole build/test matrix.
+  # clang-tidy and cppcheck are independent jobs, not steps in one job, so they run in parallel -
+  # each does its own full build rather than sharing one, the same tradeoff ci.yml's
+  # build-test-alpine job already made (see its comment) for the same reason.
   clang-tidy:
     name: static-analysis (clang-tidy)
     runs-on: ubuntu-latest
@@ -95,5 +97,83 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           if grep -qE ': (warning|error): ' clang-tidy-output.txt; then
+            exit 1
+          fi
+
+  cppcheck:
+    name: static-analysis (cppcheck)
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.24
+    timeout-minutes: 15
+    steps:
+      - name: Install build dependencies
+        run: |
+          apk add --no-cache \
+            cmake ninja git g++ cppcheck \
+            protobuf-dev \
+            grpc-dev \
+            abseil-cpp-dev \
+            c-ares-dev \
+            re2-dev \
+            openssl-dev \
+            zlib-dev \
+            spdlog-dev \
+            gflags-dev \
+            gtest-dev
+
+      - uses: actions/checkout@v5
+
+      # See ci.yml's build-test-alpine job for the same EventLoop fork pin and rationale.
+      - name: Build and install EventLoop
+        run: |
+          git clone https://github.com/anderewrey/EventLoop.git /tmp/EventLoop
+          cd /tmp/EventLoop
+          git checkout d5d29a0349f3159067df0c3ff2741f1e984679f0
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+            -DCMAKE_CXX_COMPILER=g++
+          cmake --build build
+          cmake --install build
+          rm -rf /tmp/EventLoop
+
+      - name: Configure
+        run: |
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++ \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - name: Build
+        run: cmake --build build
+
+      # A different engine than clang-tidy (not LLVM-based), so it surfaces a different set of
+      # findings. -i build skips the generated protobuf/gRPC sources as primary check targets, but
+      # protoc's own version-guard #error (in the header they still transitively include) isn't
+      # this project's code either, so preprocessorErrorDirective is suppressed outright.
+      - name: Run cppcheck
+        run: |
+          cppcheck --project=build/compile_commands.json \
+            --enable=warning,performance,portability \
+            --suppress=missingIncludeSystem \
+            --suppress=preprocessorErrorDirective \
+            --inline-suppr \
+            --template=gcc \
+            -i build \
+            > cppcheck-output.txt 2>&1 || true
+          cat cppcheck-output.txt
+
+      - name: Annotate warnings
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        run: |
+          grep -E ': (warning|error|performance|portability): ' cppcheck-output.txt | while IFS= read -r diag; do
+            file=$(echo "$diag" | cut -d: -f1)
+            lineno=$(echo "$diag" | cut -d: -f2)
+            col=$(echo "$diag" | cut -d: -f3)
+            message=$(echo "$diag" | cut -d: -f4- | sed -E 's/^ (warning|error|performance|portability): //')
+            echo "::warning file=${file},line=${lineno},col=${col}::${message}"
+          done
+
+      - name: Fail on any warning (full repo pass)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if grep -qE ': (warning|error|performance|portability): ' cppcheck-output.txt; then
             exit 1
           fi

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,8 +10,12 @@ on:
 permissions:
   contents: read
 
+# github.event.pull_request.head.sha (falling back to github.sha for push/workflow_dispatch) keys
+# this on the commit, not github.ref: a push to a branch with an open PR against master fires both
+# a push and a pull_request event for the same commit, each with a different ref - keying on ref
+# would let both run to completion instead of the later one cancelling the earlier duplicate.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -25,20 +29,21 @@ jobs:
           python-version: '3.x'
       - uses: pre-commit/action@v3.0.1
 
-  # clang-tidy and cppcheck are independent jobs, not steps in one job, so they run in parallel -
-  # each does its own full build rather than sharing one, the same tradeoff ci.yml's
-  # build-test-alpine job already made (see its comment) for the same reason.
-  clang-tidy:
-    name: static-analysis (clang-tidy)
+  # Builds once and shares compile_commands.json plus the generated protobuf/gRPC headers with
+  # both analysis jobs below, instead of each doing its own full build: neither clang-tidy nor
+  # cppcheck links or runs anything, and this project's CMake has no compiler-conditional flags, so
+  # which compiler produces these doesn't change what either tool sees.
+  build:
+    name: static-analysis (build)
     runs-on: ubuntu-latest
     container:
       image: alpine:3.24
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - name: Install build dependencies
         run: |
           apk add --no-cache \
-            cmake ninja git clang clang-extra-tools gcc binutils \
+            cmake ninja git clang \
             protobuf-dev \
             grpc-dev \
             abseil-cpp-dev \
@@ -73,44 +78,40 @@ jobs:
       - name: Build
         run: cmake --build build
 
-      - name: Run clang-tidy
-        run: |
-          : > clang-tidy-output.txt
-          find applications common protobuf_utils rg_service -name '*.cpp' | while IFS= read -r f; do
-            clang-tidy -p build "$f" >> clang-tidy-output.txt 2>&1 || true
-          done
-          cat clang-tidy-output.txt
+      - name: Upload compile_commands.json and generated sources
+        uses: actions/upload-artifact@v4
+        with:
+          name: static-analysis-build
+          path: |
+            build/compile_commands.json
+            build/rg_service/generated
+          retention-days: 1
 
-      # Turns each clang-tidy diagnostic line into a native GitHub Actions warning annotation.
-      - name: Annotate warnings
-        if: github.event_name == 'pull_request' || github.event_name == 'push'
-        run: |
-          grep -E ': (warning|error): ' clang-tidy-output.txt | while IFS= read -r diag; do
-            file=$(echo "$diag" | cut -d: -f1)
-            lineno=$(echo "$diag" | cut -d: -f2)
-            col=$(echo "$diag" | cut -d: -f3)
-            message=$(echo "$diag" | cut -d: -f4- | sed -E 's/^ (warning|error): //')
-            echo "::warning file=${file},line=${lineno},col=${col}::${message}"
-          done
-
-      - name: Fail on any warning (full repo pass)
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if grep -qE ': (warning|error): ' clang-tidy-output.txt; then
-            exit 1
-          fi
-
-  cppcheck:
-    name: static-analysis (cppcheck)
+  # clang-tidy and cppcheck as two entries of one matrix, instead of two hand-duplicated jobs -
+  # each still installs its own analysis tool and its own EventLoop (needed for header resolution,
+  # but fast enough not to be worth sharing - only the whole-project compile above was).
+  analysis:
+    name: static-analysis (${{ matrix.tool }})
+    needs: build
     runs-on: ubuntu-latest
     container:
       image: alpine:3.24
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tool: clang-tidy
+            packages: clang clang-extra-tools
+            severity_regex: 'warning|error'
+          - tool: cppcheck
+            packages: cppcheck
+            severity_regex: 'warning|error|performance|portability'
     steps:
-      - name: Install build dependencies
+      - name: Install dependencies
         run: |
           apk add --no-cache \
-            cmake ninja git g++ cppcheck \
+            cmake ninja git g++ ${{ matrix.packages }} \
             protobuf-dev \
             grpc-dev \
             abseil-cpp-dev \
@@ -124,7 +125,9 @@ jobs:
 
       - uses: actions/checkout@v5
 
-      # See ci.yml's build-test-alpine job for the same EventLoop fork pin and rationale.
+      # See ci.yml's build-test-alpine job for the same EventLoop fork pin and rationale. Built
+      # with g++ regardless of matrix.tool: only its headers are needed here, not a matching
+      # compiler, so there is nothing clang-tidy-specific about this step.
       - name: Build and install EventLoop
         run: |
           git clone https://github.com/anderewrey/EventLoop.git /tmp/EventLoop
@@ -136,44 +139,57 @@ jobs:
           cmake --install build
           rm -rf /tmp/EventLoop
 
-      - name: Configure
-        run: |
-          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++ \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      - uses: actions/download-artifact@v4
+        with:
+          name: static-analysis-build
+          path: build
 
-      - name: Build
-        run: cmake --build build
+      # Runs each file in its own background process (own output file, to avoid interleaved writes
+      # from concurrent appends to one file), instead of one clang-tidy process per file in series.
+      - name: Run clang-tidy
+        if: matrix.tool == 'clang-tidy'
+        run: |
+          mkdir -p /tmp/clang-tidy-out
+          find applications common protobuf_utils rg_service -name '*.cpp' -print0 | \
+            xargs -0 -P "$(nproc)" -I{} sh -c \
+              'clang-tidy -p build "$1" > "/tmp/clang-tidy-out/$(echo "$1" | tr / _).txt" 2>&1 || true' _ {}
+          cat /tmp/clang-tidy-out/*.txt > analysis-output.txt
+          cat analysis-output.txt
 
       # A different engine than clang-tidy (not LLVM-based), so it surfaces a different set of
-      # findings. -i build skips the generated protobuf/gRPC sources as primary check targets, but
-      # protoc's own version-guard #error (in the header they still transitively include) isn't
-      # this project's code either, so preprocessorErrorDirective is suppressed outright.
+      # findings. -i build skips the generated protobuf/gRPC sources as primary check targets;
+      # preprocessorErrorDirective is scoped to build/* (protoc's own version-guard #error, reached
+      # transitively through an #include there) so a real #error in this project's own code would
+      # still surface.
       - name: Run cppcheck
+        if: matrix.tool == 'cppcheck'
         run: |
           cppcheck --project=build/compile_commands.json \
+            -j "$(nproc)" \
             --enable=warning,performance,portability \
             --suppress=missingIncludeSystem \
-            --suppress=preprocessorErrorDirective \
+            --suppress=preprocessorErrorDirective:build/* \
             --inline-suppr \
             --template=gcc \
             -i build \
-            > cppcheck-output.txt 2>&1 || true
-          cat cppcheck-output.txt
+            > analysis-output.txt 2>&1 || true
+          cat analysis-output.txt
 
+      # Turns each diagnostic line into a native GitHub Actions warning annotation.
       - name: Annotate warnings
         if: github.event_name == 'pull_request' || github.event_name == 'push'
         run: |
-          grep -E ': (warning|error|performance|portability): ' cppcheck-output.txt | while IFS= read -r diag; do
+          grep -E ": (${{ matrix.severity_regex }}): " analysis-output.txt | while IFS= read -r diag; do
             file=$(echo "$diag" | cut -d: -f1)
             lineno=$(echo "$diag" | cut -d: -f2)
             col=$(echo "$diag" | cut -d: -f3)
-            message=$(echo "$diag" | cut -d: -f4- | sed -E 's/^ (warning|error|performance|portability): //')
+            message=$(echo "$diag" | cut -d: -f4- | sed -E "s/^ (${{ matrix.severity_regex }}): //")
             echo "::warning file=${file},line=${lineno},col=${col}::${message}"
           done
 
       - name: Fail on any warning (full repo pass)
         if: github.event_name == 'workflow_dispatch'
         run: |
-          if grep -qE ': (warning|error|performance|portability): ' cppcheck-output.txt; then
+          if grep -qE ": (${{ matrix.severity_regex }}): " analysis-output.txt; then
             exit 1
           fi

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install build dependencies
         run: |
           apk add --no-cache \
-            cmake ninja git clang \
+            cmake ninja git clang gcc binutils \
             protobuf-dev \
             grpc-dev \
             abseil-cpp-dev \

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,99 @@
+name: static-analysis
+
+on:
+  push:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+# Only emits annotations/exit codes, no GitHub API calls, so no checks/pull-requests write needed.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: lint (pre-commit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - uses: pre-commit/action@v3.0.1
+
+  # Kept separate from ci.yml so it runs on every push without the whole build/test matrix.
+  clang-tidy:
+    name: static-analysis (clang-tidy)
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.24
+    timeout-minutes: 15
+    steps:
+      - name: Install build dependencies
+        run: |
+          apk add --no-cache \
+            cmake ninja git clang clang-extra-tools gcc binutils \
+            protobuf-dev \
+            grpc-dev \
+            abseil-cpp-dev \
+            c-ares-dev \
+            re2-dev \
+            openssl-dev \
+            zlib-dev \
+            spdlog-dev \
+            gflags-dev \
+            gtest-dev
+
+      - uses: actions/checkout@v5
+
+      # See ci.yml's build-test-alpine job for the same EventLoop fork pin and rationale.
+      - name: Build and install EventLoop
+        run: |
+          git clone https://github.com/anderewrey/EventLoop.git /tmp/EventLoop
+          cd /tmp/EventLoop
+          git checkout d5d29a0349f3159067df0c3ff2741f1e984679f0
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+            -DCMAKE_CXX_COMPILER=clang++
+          cmake --build build
+          cmake --install build
+          rm -rf /tmp/EventLoop
+
+      - name: Configure
+        run: |
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      # Full build, not just codegen, so compile_commands.json's flags match what actually compiles.
+      - name: Build
+        run: cmake --build build
+
+      - name: Run clang-tidy
+        run: |
+          : > clang-tidy-output.txt
+          find applications common protobuf_utils rg_service -name '*.cpp' | while IFS= read -r f; do
+            clang-tidy -p build "$f" >> clang-tidy-output.txt 2>&1 || true
+          done
+          cat clang-tidy-output.txt
+
+      # Turns each clang-tidy diagnostic line into a native GitHub Actions warning annotation.
+      - name: Annotate warnings
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        run: |
+          grep -E ': (warning|error): ' clang-tidy-output.txt | while IFS= read -r diag; do
+            file=$(echo "$diag" | cut -d: -f1)
+            lineno=$(echo "$diag" | cut -d: -f2)
+            col=$(echo "$diag" | cut -d: -f3)
+            message=$(echo "$diag" | cut -d: -f4- | sed -E 's/^ (warning|error): //')
+            echo "::warning file=${file},line=${lineno},col=${col}::${message}"
+          done
+
+      - name: Fail on any warning (full repo pass)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if grep -qE ': (warning|error): ' clang-tidy-output.txt; then
+            exit 1
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,24 @@ repos:
         #args: [ "--disable MD013 MD024 -- " ]
         args: [ --config=markdownlint.yaml ]
 
-  # - repo: https://github.com/cheshirekow/cmake-format-precommit
-  #   rev: v0.6.13
-  #   hooks:
-  #     - id: cmake-format
-  #     - id: cmake-lint
-  #       # Disable rule C0307: indentation width, because it does not match the default CLion indentation.
-  #       args: [ --line-width=120, --disabled-codes=C0307 ]
+  # cmake-format (the autofixer) is intentionally not enabled: it reformats CMakeLists.txt into
+  # cmakelang's own dense packing (e.g. splitting single-arg set() calls onto two lines, reflowing
+  # multi-line comments into paragraphs), which fights this repo's existing hand-formatted style
+  # instead of matching it - confirmed by a real CI run. cmake-lint alone only reports, never
+  # rewrites, and already passes clean.
+  - repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.13
+    hooks:
+      # cmakelang doesn't declare pyyaml as a hard dependency, but needs it at runtime to load a
+      # YAML-format config file - without this it crashes with "ModuleNotFoundError: No module
+      # named 'yaml'" before ever reading a CMakeLists.txt.
+      - id: cmake-lint
+        additional_dependencies: [pyyaml]
+        # Disable rule C0307: indentation width, because it does not match the default CLion indentation.
+        args: [ --line-width=120, --disabled-codes=C0307 ]
+        # portfile.cmake follows vcpkg's own upstream convention (e.g. an inline SHA512 hash always
+        # exceeds 120 columns), not this project's style.
+        exclude: ^vcpkg/ports/.*/portfile\.cmake$
 
   - repo: https://github.com/cpplint/cpplint
     rev: 2.0.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,9 +42,15 @@ repos:
         additional_dependencies: [pyyaml]
         # Disable rule C0307: indentation width, because it does not match the default CLion indentation.
         args: [ --line-width=120, --disabled-codes=C0307 ]
-        # portfile.cmake follows vcpkg's own upstream convention (e.g. an inline SHA512 hash always
-        # exceeds 120 columns), not this project's style.
         exclude: ^vcpkg/ports/.*/portfile\.cmake$
+      # portfile.cmake follows vcpkg's own upstream convention for its inline SHA512 hash, which
+      # always exceeds 120 columns - only --line-width is raised here, every other rule (naming,
+      # docstrings, ...) still applies, same two-entry split cpplint uses below for route_guide_db.inc.
+      - id: cmake-lint
+        name: cmake-lint (portfile.cmake)
+        additional_dependencies: [pyyaml]
+        args: [ --line-width=200, --disabled-codes=C0307 ]
+        files: ^vcpkg/ports/.*/portfile\.cmake$
 
   - repo: https://github.com/cpplint/cpplint
     rev: 2.0.2

--- a/cmake/CompilerCompatibilityCheck.cmake
+++ b/cmake/CompilerCompatibilityCheck.cmake
@@ -40,11 +40,11 @@ if(NOT USING_VCPKG AND NOT SKIP_COMPILER_CHECK)
     set(COMPILER_MISMATCH FALSE)
     set(MISMATCH_DETAILS "")
 
-    foreach(LIB_PATH ${LIBS_TO_CHECK})
-        if(EXISTS "${LIB_PATH}")
+    foreach(lib_path ${LIBS_TO_CHECK})
+        if(EXISTS "${lib_path}")
             # Extract compiler info from the library's .comment section
             execute_process(
-                COMMAND readelf -p .comment "${LIB_PATH}"
+                COMMAND readelf -p .comment "${lib_path}"
                 OUTPUT_VARIABLE LIB_COMMENT
                 ERROR_QUIET
                 OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -78,21 +78,21 @@ if(NOT USING_VCPKG AND NOT SKIP_COMPILER_CHECK)
             if(NOT "${LIB_COMPILER_TYPE}" STREQUAL "${CURRENT_COMPILER_TYPE}")
                 set(COMPILER_MISMATCH TRUE)
                 string(APPEND MISMATCH_DETAILS
-                    "  ${LIB_PATH}:\n"
+                    "  ${lib_path}:\n"
                     "    Built with: ${LIB_COMPILER_TYPE} ${LIB_COMPILER_VERSION}\n"
                     "    Your compiler: ${CURRENT_COMPILER_TYPE} ${CURRENT_COMPILER_VERSION}\n"
                 )
             elseif(NOT "${LIB_COMPILER_VERSION}" STREQUAL "${CURRENT_COMPILER_VERSION}")
                 # Major.minor version mismatch is a warning, not fatal
                 message(WARNING
-                    "Compiler version mismatch for ${LIB_PATH}:\n"
+                    "Compiler version mismatch for ${lib_path}:\n"
                     "  Library built with: ${LIB_COMPILER_TYPE} ${LIB_COMPILER_VERSION}\n"
                     "  Your compiler: ${CURRENT_COMPILER_TYPE} ${CURRENT_COMPILER_VERSION}\n"
                     "  This may cause issues with template-heavy code."
                 )
             endif()
 
-            message(STATUS "Checked ${LIB_PATH}: ${LIB_COMPILER_TYPE} ${LIB_COMPILER_VERSION}")
+            message(STATUS "Checked ${lib_path}: ${LIB_COMPILER_TYPE} ${LIB_COMPILER_VERSION}")
         endif()
     endforeach()
 

--- a/cmake/ProtobufGrpcGenerate.cmake
+++ b/cmake/ProtobufGrpcGenerate.cmake
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2025 anderewrey
 
+include(FindGrpcPlugin)
+
 # ProtobufGrpcGenerate.cmake
 # Helper function for generating protobuf and gRPC C++ code from .proto files
 #
@@ -15,9 +17,6 @@
 # This function generates both:
 #   - Standard protobuf C++ files (.pb.h, .pb.cc)
 #   - gRPC service C++ files (.grpc.pb.h, .grpc.pb.cc)
-
-include(FindGrpcPlugin)
-
 function(protobuf_grpc_generate)
     cmake_parse_arguments(
         ARG

--- a/cmake/VcpkgAutoDetect.cmake
+++ b/cmake/VcpkgAutoDetect.cmake
@@ -22,7 +22,7 @@ if(NOT DEFINED CACHE{VCPKG_ROOT})
     else()
         # Try common locations (ordered by likelihood)
         # Paths are platform-aware: Unix paths for Linux/macOS, Windows paths for Windows
-        set(_VCPKG_SEARCH_PATHS
+        set(_vcpkg_search_paths
             # User development directories (Unix-style)
             "$ENV{HOME}/git/vcpkg"
             "$ENV{HOME}/vcpkg"
@@ -59,16 +59,16 @@ if(NOT DEFINED CACHE{VCPKG_ROOT})
             "${CMAKE_SOURCE_DIR}/../vcpkg"
         )
 
-        foreach(_PATH ${_VCPKG_SEARCH_PATHS})
-            if(EXISTS "${_PATH}/scripts/buildsystems/vcpkg.cmake")
-                set(VCPKG_ROOT "${_PATH}" CACHE PATH "Path to vcpkg installation")
+        foreach(path ${_vcpkg_search_paths})
+            if(EXISTS "${path}/scripts/buildsystems/vcpkg.cmake")
+                set(VCPKG_ROOT "${path}" CACHE PATH "Path to vcpkg installation")
                 message(STATUS "VCPKG_ROOT auto-detected: ${VCPKG_ROOT}")
                 break()
             endif()
         endforeach()
 
         if(NOT DEFINED CACHE{VCPKG_ROOT})
-            message(WARNING "VCPKG_ROOT not found. Searched: ${_VCPKG_SEARCH_PATHS}")
+            message(WARNING "VCPKG_ROOT not found. Searched: ${_vcpkg_search_paths}")
         endif()
     endif()
 endif()

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -110,7 +110,7 @@ port) to avoid conflicts between parallel test runs.
 ## Continuous integration
 
 [ci.yml][ci-workflow] runs the test suite as a `build-test-alpine` job with three matrix variants, each an
-Alpine container with a different compiler and sanitizer combination, plus a separate lint job.
+Alpine container with a different compiler and sanitizer combination.
 `fail-fast` is disabled, so a failure in one variant does not block the others from reporting their
 own result. Each variant installs its own apk packages and rebuilds EventLoop from source
 independently rather than sharing a container image, since a prebuilt-image approach was tried and
@@ -156,6 +156,15 @@ stack-use-after-return detection, leak detection, and static initialization orde
 Stack traces from this job are symbolized via `llvm22-symbolizer`, installed alongside Clang and
 symlinked to the unversioned `llvm-symbolizer` name the sanitizer runtime expects. Neither the
 `clang` nor the `compiler-rt` Alpine package ships a symbolizer binary.
+
+### Static analysis
+
+[static-analysis.yml][static-analysis-workflow] runs `lint` (pre-commit) and `clang-tidy` as their
+own workflow, separate from the build/test matrix above, on every push. clang-tidy has two entry
+points sharing one build: a `pull_request` or `push` run that annotates diagnostics without
+failing the job, and a `workflow_dispatch` run that fails on any diagnostic for a deliberate,
+whole-repo pass. See `static-analysis.yml` for why it is a separate workflow, and `.clang-tidy`
+for the check selection.
 
 ## Adding new tests
 
@@ -233,6 +242,7 @@ ctest --test-dir cmake-build-vcpkg-debug-gcc
 
 <!-- Reference links -->
 [ci-workflow]: /.github/workflows/ci.yml
+[static-analysis-workflow]: /.github/workflows/static-analysis.yml
 [reactor-client]: /applications/reactor/reactor_client.h
 [reactor-client-routeguide]: /applications/reactor/reactor_client_routeguide.h
 [unary-test]: /applications/reactor/tests/active_unary_reactor_test.cpp

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -159,12 +159,14 @@ symlinked to the unversioned `llvm-symbolizer` name the sanitizer runtime expect
 
 ### Static analysis
 
-[static-analysis.yml][static-analysis-workflow] runs `lint` (pre-commit) and `clang-tidy` as their
-own workflow, separate from the build/test matrix above, on every push. clang-tidy has two entry
-points sharing one build: a `pull_request` or `push` run that annotates diagnostics without
-failing the job, and a `workflow_dispatch` run that fails on any diagnostic for a deliberate,
-whole-repo pass. See `static-analysis.yml` for why it is a separate workflow, and `.clang-tidy`
-for the check selection.
+[static-analysis.yml][static-analysis-workflow] runs `lint` (pre-commit), `clang-tidy`, and
+`cppcheck` as their own workflow, separate from the build/test matrix above, on every push. A
+`build` job compiles once and shares `compile_commands.json` and the generated protobuf/gRPC
+headers with both analysis tools, which run as one matrix job's two entries rather than as
+separate jobs. Each entry has two triggers: a `pull_request` or `push` run that annotates
+diagnostics without failing the job, and a `workflow_dispatch` run that fails on any diagnostic
+for a deliberate, whole-repo pass. See `static-analysis.yml` for why it is a separate workflow,
+and `.clang-tidy` for clang-tidy's check selection.
 
 ## Adding new tests
 


### PR DESCRIPTION
Adds a clang-tidy job scoped to this project's own sources (see
.clang-tidy's HeaderFilterRegex). It runs two ways: on push/pull_request,
diagnostics become non-blocking GitHub Actions annotations; on
workflow_dispatch, the same analysis fails on any diagnostic, for a
deliberate, manually-triggered full pass. misc-include-cleaner is
disabled - it flagged umbrella-header symbol use as 63 of 99 diagnostics
in the first full run, dwarfing every other check.

Enables the already-scaffolded cmake-lint pre-commit hook (report-only,
never rewrites files). cmake-format is deliberately left disabled: it
reformats CMakeLists.txt into cmakelang's own dense packing instead of
matching this repo's existing style. Fixes three cmake-lint naming
findings (_PATH, _VCPKG_SEARCH_PATHS, LIB_PATH mixed public-style casing
with local/loop scope, unlike this project's genuine cache variables in
the same files), excludes vcpkg/ports/*/portfile.cmake's vendored-style
inline SHA512 from the line-length check, and repositions an include() so
protobuf_grpc_generate's existing docstring is recognized.

Both checks live in a new static-analysis.yml, separate from ci.yml's
build/test matrix: it runs on every push without rebuilding the whole
matrix, and needs only contents:read instead of ci.yml's broader
checks/pull-requests write access. The lint (pre-commit) job moves here
from ci.yml for the same reason.