### PR TITLE
Add a coverage workflow measuring gcovr, lcov, and llvm-cov side by side

### DIFF
--- a/.github/scripts/compare-coverage.py
+++ b/.github/scripts/compare-coverage.py
@@ -160,12 +160,15 @@ def emit_cost(metas, out):
     out.append("")
 
 
+_METRIC_LABELS = {"lines": "line", "branches": "branch", "functions": "function", "regions": "region"}
+
+
 def emit_per_file(reports, metric, out):
     """Emit one row per source file, with the metric as measured by each tool."""
     tools = list(reports)
     every_file = sorted({name for files in reports.values() for name in files})
 
-    out.append(f"## Per-file {metric[:-1] if metric.endswith('s') else metric} coverage\n")
+    out.append(f"## Per-file {_METRIC_LABELS.get(metric, metric)} coverage\n")
     out.append("| File | " + " | ".join(tools) + " | Spread |")
     out.append("| --- | " + " | ".join("---" for _ in tools) + " | --- |")
     for name in every_file:

--- a/.github/scripts/compare-coverage.py
+++ b/.github/scripts/compare-coverage.py
@@ -1,0 +1,260 @@
+"""Compare the coverage reports produced by gcovr, lcov and llvm-cov over the same test suite.
+
+Reads one directory per tool, as downloaded from the coverage workflow's artifacts, and writes a
+markdown comparison to stdout. Each tool reports the same runs through a different counter format
+and a different notion of what a "branch" is, so the tables below are what makes those differences
+visible: totals per metric, per-file line and branch coverage side by side, and the set of files
+each tool reports on at all.
+
+Usage: python3 compare-coverage.py <artifact-root-dir>
+"""
+
+import json
+import os
+import re
+import sys
+
+# Order is the report order, and the first tool present becomes the per-file table's baseline.
+TOOLS = ("gcovr", "lcov", "llvm-cov")
+
+# Repository-relative path starts at one of the project's own top-level directories. gcovr reports
+# paths already relative to the root, while lcov and llvm-cov both record absolute paths, so every
+# filename is cut back to this common form before the reports can be compared per file.
+SOURCE_ROOTS = ("applications", "rg_service", "protobuf_utils", "common")
+_REL_RE = re.compile(r"(?:^|/)((?:%s)/.*)$" % "|".join(SOURCE_ROOTS))
+
+
+def relative_path(filename):
+    """Return filename as a repository-relative path, or its basename when it lies outside."""
+    match = _REL_RE.search(filename.replace(os.sep, "/"))
+    return match.group(1) if match else os.path.basename(filename)
+
+
+def percent(covered, total):
+    """Return the coverage percentage, or None when the metric has nothing to measure."""
+    return None if not total else 100.0 * covered / total
+
+
+def fmt(value, suffix="%"):
+    return "n/a" if value is None else f"{value:.1f}{suffix}"
+
+
+def counts(covered, total):
+    return "n/a" if not total else f"{covered}/{total}"
+
+
+def empty_metrics():
+    return {key: [0, 0] for key in ("lines", "branches", "functions", "regions", "mcdc")}
+
+
+def load_gcovr(path):
+    """Parse a gcovr --json-summary report."""
+    with open(os.path.join(path, "summary.json"), encoding="utf-8") as handle:
+        report = json.load(handle)
+
+    files = {}
+    for entry in report.get("files", []):
+        metrics = empty_metrics()
+        metrics["lines"] = [entry.get("line_covered", 0), entry.get("line_total", 0)]
+        metrics["branches"] = [entry.get("branch_covered", 0), entry.get("branch_total", 0)]
+        metrics["functions"] = [entry.get("function_covered", 0), entry.get("function_total", 0)]
+        files[relative_path(entry["filename"])] = metrics
+    return files
+
+
+def load_lcov(path):
+    """Parse an lcov .info tracefile.
+
+    The per-file LF/LH/BRF/BRH summary records are not trusted here: they are written by whichever
+    lcov version produced the file, whereas the DA/BRDA detail records are the raw measurement.
+    Counting the detail records keeps the definition of "covered" identical to the other two tools.
+    """
+    files = {}
+    metrics = None
+    for line in open(os.path.join(path, "lcov.info"), encoding="utf-8"):
+        line = line.strip()
+        if line.startswith("SF:"):
+            metrics = files.setdefault(relative_path(line[3:]), empty_metrics())
+        elif metrics is None:
+            continue
+        elif line.startswith("DA:"):
+            hits = line[3:].split(",")[1]
+            metrics["lines"][1] += 1
+            metrics["lines"][0] += 1 if hits not in ("0", "-") else 0
+        elif line.startswith("BRDA:"):
+            taken = line[5:].split(",")[3]
+            metrics["branches"][1] += 1
+            metrics["branches"][0] += 1 if taken not in ("0", "-") else 0
+        elif line.startswith("FNDA:"):
+            hits = line[5:].split(",")[0]
+            metrics["functions"][1] += 1
+            metrics["functions"][0] += 1 if hits not in ("0", "-") else 0
+        elif line == "end_of_record":
+            metrics = None
+    return files
+
+
+def load_llvm_cov(path):
+    """Parse an llvm-cov export JSON report."""
+    with open(os.path.join(path, "llvm-cov.json"), encoding="utf-8") as handle:
+        report = json.load(handle)
+
+    files = {}
+    for entry in report["data"][0].get("files", []):
+        summary = entry.get("summary", {})
+        metrics = empty_metrics()
+        for key in ("lines", "branches", "functions", "regions", "mcdc"):
+            block = summary.get(key)
+            if block:
+                metrics[key] = [block.get("covered", 0), block.get("count", 0)]
+        files[relative_path(entry["filename"])] = metrics
+    return files
+
+
+LOADERS = {"gcovr": load_gcovr, "lcov": load_lcov, "llvm-cov": load_llvm_cov}
+
+
+def load_meta(path):
+    try:
+        with open(os.path.join(path, "meta.json"), encoding="utf-8") as handle:
+            return json.load(handle)
+    except OSError:
+        return {}
+
+
+def totals(files):
+    total = empty_metrics()
+    for metrics in files.values():
+        for key, (covered, count) in metrics.items():
+            total[key][0] += covered
+            total[key][1] += count
+    return total
+
+
+def emit_totals(reports, metas, out):
+    out.append("## Totals\n")
+    out.append("| Tool | Version | Lines | Line % | Branches | Branch % | Functions | Regions | MC/DC | Files |")
+    out.append("| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |")
+    for tool, files in reports.items():
+        total = totals(files)
+        meta = metas.get(tool, {})
+        out.append(
+            f"| {tool} | {meta.get('version', 'n/a')} "
+            f"| {counts(*total['lines'])} | {fmt(percent(*total['lines']))} "
+            f"| {counts(*total['branches'])} | {fmt(percent(*total['branches']))} "
+            f"| {fmt(percent(*total['functions']))} | {fmt(percent(*total['regions']))} "
+            f"| {fmt(percent(*total['mcdc']))} | {len(files)} |"
+        )
+    out.append("")
+
+
+def emit_cost(metas, out):
+    out.append("## Cost\n")
+    out.append("| Tool | Build + test (s) | Report generation (s) | Raw counter data (KiB) | HTML report (KiB) |")
+    out.append("| --- | --- | --- | --- | --- |")
+    for tool, meta in metas.items():
+        out.append(
+            f"| {tool} | {meta.get('build_test_seconds', 'n/a')} | {meta.get('report_seconds', 'n/a')} "
+            f"| {meta.get('raw_kib', 'n/a')} | {meta.get('html_kib', 'n/a')} |"
+        )
+    out.append("")
+
+
+def emit_per_file(reports, metric, out):
+    """Emit one row per source file, with the metric as measured by each tool."""
+    tools = list(reports)
+    every_file = sorted({name for files in reports.values() for name in files})
+
+    out.append(f"## Per-file {metric[:-1] if metric.endswith('s') else metric} coverage\n")
+    out.append("| File | " + " | ".join(tools) + " | Spread |")
+    out.append("| --- | " + " | ".join("---" for _ in tools) + " | --- |")
+    for name in every_file:
+        cells, values = [], []
+        for tool in tools:
+            metrics = reports[tool].get(name)
+            if metrics is None:
+                cells.append("absent")
+                continue
+            value = percent(*metrics[metric])
+            cells.append("n/a" if value is None else f"{value:.1f}% ({counts(*metrics[metric])})")
+            if value is not None:
+                values.append(value)
+        spread = f"{max(values) - min(values):.1f} pts" if len(values) > 1 else "n/a"
+        out.append(f"| `{name}` | " + " | ".join(cells) + f" | {spread} |")
+    out.append("")
+
+
+def emit_file_sets(reports, out):
+    """Report which files a tool includes that another one does not."""
+    sets = {tool: set(files) for tool, files in reports.items()}
+    lines = []
+    for tool, names in sets.items():
+        others = set().union(*(other for name, other in sets.items() if name != tool)) if len(sets) > 1 else set()
+        only = sorted(names - others)
+        if only:
+            lines.append(f"- Reported only by {tool}: " + ", ".join(f"`{name}`" for name in only))
+    if lines:
+        out.append("## Reported file sets differ\n")
+        out.extend(lines)
+        out.append("")
+
+
+def emit_gcovr_throw_branches(root, out):
+    """Compare gcovr's default branch total against the same data with throw branches excluded.
+
+    GCC emits a branch for every implicit exception-unwind edge, which llvm-cov has no counterpart
+    for, so this is the single largest source of branch-percentage disagreement between the two
+    counter formats on C++ code.
+    """
+    path = os.path.join(root, "coverage-gcovr", "summary-nothrow.json")
+    try:
+        with open(path, encoding="utf-8") as handle:
+            report = json.load(handle)
+    except OSError:
+        return
+
+    out.append("## gcovr branch total, with and without throw branches\n")
+    out.append("| View | Branches | Branch % |")
+    out.append("| --- | --- | --- |")
+    out.append(f"| default | {report.get('branch_total', 0)} | see totals above |")
+    out.append(
+        f"| --exclude-throw-branches | {report.get('branch_total', 0)} "
+        f"| {fmt(report.get('branch_percent'))} |"
+    )
+    out.append("")
+
+
+def main():
+    root = sys.argv[1] if len(sys.argv) > 1 else "."
+
+    reports, metas = {}, {}
+    for tool in TOOLS:
+        path = os.path.join(root, f"coverage-{tool}")
+        if not os.path.isdir(path):
+            continue
+        try:
+            reports[tool] = LOADERS[tool](path)
+        except (OSError, KeyError, ValueError) as error:
+            print(f"<!-- {tool}: {type(error).__name__}: {error} -->")
+            continue
+        metas[tool] = load_meta(path)
+
+    if not reports:
+        print("No coverage reports found: every measurement job failed or produced no artifact.")
+        return 1
+
+    out = ["# Coverage tool comparison\n"]
+    out.append(f"Tools reporting: {', '.join(reports)}. ")
+    out.append("All three measured the same test suite, over the same source filters.\n")
+    emit_totals(reports, metas, out)
+    emit_cost(metas, out)
+    emit_gcovr_throw_branches(root, out)
+    emit_per_file(reports, "lines", out)
+    emit_per_file(reports, "branches", out)
+    emit_file_sets(reports, out)
+    print("\n".join(out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,259 @@
+name: coverage
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  # Three tools measuring the exact same test suite, so the compare job can attribute any
+  # difference in the reported numbers to the tool, not to a difference in what ran. gcovr and lcov
+  # share the gcc-debug instrumentation (both read the same .gcno/.gcda counters, gcovr in Python
+  # and lcov in Perl); llvm-cov needs its own Clang-instrumented build, since GCC and Clang counter
+  # formats are not cross-readable. See cmake/Coverage.cmake for why the two modes are compiler-bound.
+  measure:
+    name: measure (${{ matrix.tool }})
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.24
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tool: gcovr
+            cxx_compiler: g++
+            coverage_mode: gcov
+            packages: g++ py3-pip
+          - tool: lcov
+            cxx_compiler: g++
+            coverage_mode: gcov
+            packages: g++ lcov
+          - tool: llvm-cov
+            cxx_compiler: clang++
+            coverage_mode: llvm
+            packages: clang compiler-rt llvm22
+    steps:
+      - name: Install build dependencies
+        run: |
+          apk add --no-cache \
+            cmake ninja git curl zip unzip tar bash ${{ matrix.packages }} \
+            protobuf-dev \
+            grpc-dev \
+            abseil-cpp-dev \
+            c-ares-dev \
+            re2-dev \
+            openssl-dev \
+            zlib-dev \
+            spdlog-dev \
+            gflags-dev \
+            gtest-dev
+          if [ "${{ matrix.tool }}" = "gcovr" ]; then
+            pip install --break-system-packages gcovr==8.6
+          fi
+
+      - uses: actions/checkout@v5
+
+      # See ci.yml's build-test-alpine job for the same EventLoop-via-vcpkg approach and rationale.
+      - name: Build and install EventLoop via vcpkg
+        env:
+          VCPKG_FORCE_SYSTEM_BINARIES: "1"
+        run: |
+          git clone --depth 1 https://github.com/microsoft/vcpkg.git /tmp/vcpkg
+          /tmp/vcpkg/bootstrap-vcpkg.sh -musl -disableMetrics
+          case "${{ matrix.cxx_compiler }}" in
+            clang++) triplet=x64-linux-clang-release ;;
+            *) triplet=x64-linux-gcc-release ;;
+          esac
+          /tmp/vcpkg/vcpkg install eventloop --classic --triplet="$triplet" \
+            --overlay-triplets=vcpkg/triplets --overlay-ports=vcpkg/ports
+          cp -r /tmp/vcpkg/packages/eventloop_$triplet/* /usr/local/
+          rm -rf /tmp/vcpkg
+
+      - name: Configure
+        run: |
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} \
+            -DENABLE_COVERAGE=${{ matrix.coverage_mode }}
+
+      - name: Build
+        run: |
+          date +%s > /tmp/build_start
+          cmake --build build
+
+      # llvm-cov needs one profile per test PROCESS, not one for the whole ctest run: gtest_discover_tests
+      # registers one ctest entry per TEST_F, so each is its own process and %m (this binary's own build-ID
+      # hash) plus %p (pid) keeps every one of them from overwriting the last, the same problem gcov's
+      # per-process .gcda files solve by construction (one file per translation unit, updated in place).
+      - name: Test
+        env:
+          LLVM_PROFILE_FILE: "/tmp/profiles/%m-%p.profraw"
+        run: |
+          mkdir -p /tmp/profiles
+          ctest --test-dir build --output-on-failure
+          echo "test_end=$(date +%s)" >> "$GITHUB_ENV"
+          echo "build_start=$(cat /tmp/build_start)" >> "$GITHUB_ENV"
+
+      - name: Generate gcovr report
+        if: matrix.tool == 'gcovr'
+        run: |
+          mkdir -p coverage-gcovr
+          report_start=$(date +%s)
+          # --exclude-throw-branches is reported separately below, not applied to the primary
+          # report: GCC's implicit exception-unwind branches have no llvm-cov counterpart, so
+          # dropping them from the default report would make gcovr's branch % look closer to
+          # llvm-cov's for the wrong reason (an arbitrary exclusion), not a real agreement.
+          filters="--filter applications/ --filter rg_service/ --filter protobuf_utils/ --filter common/"
+          gcovr --root . build $filters --exclude '.*/tests/.*' --exclude '.*\.pb\.(h|cc)$' \
+            --json-summary-pretty --json-summary coverage-gcovr/summary.json \
+            --html-details coverage-gcovr/html/index.html --print-summary > coverage-gcovr/stdout.txt
+          gcovr --root . build $filters --exclude '.*/tests/.*' --exclude '.*\.pb\.(h|cc)$' \
+            --exclude-throw-branches --json-summary coverage-gcovr/summary-nothrow.json --json-summary-pretty
+          gcovr --version | head -1 | awk '{print $2}' > /tmp/tool_version
+          find build -name '*.gcda' -o -name '*.gcno' | xargs du -ck 2>/dev/null | tail -1 | awk '{print $1}' \
+            > /tmp/raw_kib
+          du -sk coverage-gcovr/html | awk '{print $1}' > /tmp/html_kib
+          echo "report_seconds=$(( $(date +%s) - report_start ))" >> "$GITHUB_ENV"
+
+      # geninfo/genhtml (lcov's own tools) read the same .gcno/.gcda gcovr just consumed above -
+      # same GCC counter format, different report generator, which is the whole point of running
+      # both against one build instead of two separate instrumented builds.
+      - name: Generate lcov report
+        if: matrix.tool == 'lcov'
+        run: |
+          mkdir -p coverage-lcov
+          report_start=$(date +%s)
+          lcov --capture --directory build --output-file coverage-lcov/lcov.info \
+            --rc branch_coverage=1 --ignore-errors mismatch,negative,unused
+          lcov --extract coverage-lcov/lcov.info \
+            "$(pwd)/applications/*" "$(pwd)/rg_service/*" "$(pwd)/protobuf_utils/*" "$(pwd)/common/*" \
+            --output-file coverage-lcov/lcov.info --rc branch_coverage=1 --ignore-errors unused
+          lcov --remove coverage-lcov/lcov.info '*/tests/*' '*.pb.h' '*.pb.cc' \
+            --output-file coverage-lcov/lcov.info --rc branch_coverage=1 --ignore-errors unused
+          genhtml coverage-lcov/lcov.info --output-directory coverage-lcov/html --branch-coverage
+          lcov --summary coverage-lcov/lcov.info --rc branch_coverage=1 | tee coverage-lcov/stdout.txt
+          lcov --version | grep -oE '[0-9]+\.[0-9]+' | head -1 > /tmp/tool_version
+          find build -name '*.gcda' -o -name '*.gcno' | xargs du -ck 2>/dev/null | tail -1 | awk '{print $1}' \
+            > /tmp/raw_kib
+          du -sk coverage-lcov/html | awk '{print $1}' > /tmp/html_kib
+          echo "report_seconds=$(( $(date +%s) - report_start ))" >> "$GITHUB_ENV"
+
+      - name: Generate llvm-cov report
+        if: matrix.tool == 'llvm-cov'
+        run: |
+          mkdir -p coverage-llvm-cov
+          report_start=$(date +%s)
+          llvm22-profdata merge -sparse /tmp/profiles/*.profraw -o coverage-llvm-cov/merged.profdata
+
+          # A merged profdata has no record of which binaries produced it, so llvm-cov needs each
+          # ctest binary passed explicitly. Same five names as REACTOR_TESTS in
+          # applications/reactor/tests/CMakeLists.txt.
+          object_args=""
+          for name in active_unary_reactor_test active_read_reactor_test active_write_reactor_test \
+                      active_bidi_reactor_test client_reactor_integration_test; do
+            object_args="$object_args -object=build/applications/reactor/tests/$name"
+          done
+
+          llvm22-cov export $object_args \
+            -instr-profile=coverage-llvm-cov/merged.profdata \
+            -ignore-filename-regex='.*/tests/.*|.*\.pb\.(h|cc)$|.*/vcpkg_installed/.*' \
+            > coverage-llvm-cov/llvm-cov.json
+
+          llvm22-cov show $object_args \
+            -instr-profile=coverage-llvm-cov/merged.profdata \
+            -ignore-filename-regex='.*/tests/.*|.*\.pb\.(h|cc)$|.*/vcpkg_installed/.*' \
+            -format=html -show-instantiations -show-branches=count \
+            -output-dir=coverage-llvm-cov/html
+
+          llvm22-cov report $object_args \
+            -instr-profile=coverage-llvm-cov/merged.profdata \
+            -ignore-filename-regex='.*/tests/.*|.*\.pb\.(h|cc)$|.*/vcpkg_installed/.*' \
+            | tee coverage-llvm-cov/stdout.txt
+
+          clang --version | head -1 | awk '{print $3}' > /tmp/tool_version
+          du -sk /tmp/profiles | awk '{print $1}' > /tmp/raw_kib
+          du -sk coverage-llvm-cov/html | awk '{print $1}' > /tmp/html_kib
+          echo "report_seconds=$(( $(date +%s) - report_start ))" >> "$GITHUB_ENV"
+
+      - name: Write metadata
+        run: |
+          dir="coverage-${{ matrix.tool }}"
+          cat > "$dir/meta.json" <<JSON
+          {
+            "tool": "${{ matrix.tool }}",
+            "version": "$(cat /tmp/tool_version)",
+            "build_test_seconds": $(( test_end - build_start )),
+            "report_seconds": $report_seconds,
+            "raw_kib": $(cat /tmp/raw_kib),
+            "html_kib": $(cat /tmp/html_kib)
+          }
+          JSON
+          cat "$dir/meta.json"
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.tool }}
+          path: coverage-${{ matrix.tool }}
+          retention-days: 14
+
+  compare:
+    name: compare tool reports
+    needs: measure
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          path: reports
+
+      - name: Build comparison
+        run: |
+          python3 .github/scripts/compare-coverage.py reports | tee comparison.md
+
+      - name: Post to job summary
+        run: cat comparison.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on pull request
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('comparison.md', 'utf8');
+            const marker = '<!-- coverage-tool-comparison -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            const content = `${marker}\n${body}`;
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: content,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: content,
+              });
+            }

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -162,13 +162,28 @@ jobs:
           report_start=$(date +%s)
           llvm22-profdata merge -sparse /tmp/profiles/*.profraw -o coverage-llvm-cov/merged.profdata
 
-          # A merged profdata has no record of which binaries produced it, so llvm-cov needs each
-          # ctest binary passed explicitly. Same five names as REACTOR_TESTS in
-          # applications/reactor/tests/CMakeLists.txt.
+          # A merged profdata has no record of which binaries produced it, so llvm-cov needs every
+          # instrumented binary passed explicitly. gcovr/lcov instead scan the whole build/ tree for
+          # .gcno files, so they see every compiled translation unit regardless of which binary it
+          # ended up in - including the four standalone example apps ctest never runs. Passing those
+          # four here too (all built with the same instrumentation, just never executed) keeps
+          # llvm-cov's file set the same as gcovr/lcov's: without them, this project's ~800 lines of
+          # untested example-app code would silently vanish from llvm-cov's denominator instead of
+          # showing up as 0%, making the tools look further apart than they actually are.
           object_args=""
-          for name in active_unary_reactor_test active_read_reactor_test active_write_reactor_test \
-                      active_bidi_reactor_test client_reactor_integration_test; do
-            object_args="$object_args -object=build/applications/reactor/tests/$name"
+          for path in \
+            applications/reactor/tests/active_unary_reactor_test \
+            applications/reactor/tests/active_read_reactor_test \
+            applications/reactor/tests/active_write_reactor_test \
+            applications/reactor/tests/active_bidi_reactor_test \
+            applications/reactor/tests/client_reactor_integration_test \
+            applications/blocking/route_guide_sync_client \
+            applications/blocking/route_guide_sync_server \
+            applications/callback/route_guide_callback_client \
+            applications/callback/route_guide_callback_server \
+            applications/reactor/route_guide_active_reactor_client \
+          ; do
+            object_args="$object_args -object=build/$path"
           done
 
           llvm22-cov export $object_args \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -136,8 +136,12 @@ jobs:
         run: |
           mkdir -p coverage-lcov
           report_start=$(date +%s)
+          # "inconsistent" is GCC 15's geninfo reporting a mismatched end line for TEST_F bodies
+          # (GoogleTest's macro expansion confuses gcov's line tracking, not a real data problem);
+          # "mismatch" is the same false positive geninfo already reports for libstdc++/libprotobuf
+          # headers, unrelated to this project's own code.
           lcov --capture --directory build --output-file coverage-lcov/lcov.info \
-            --rc branch_coverage=1 --ignore-errors mismatch,negative,unused
+            --rc branch_coverage=1 --ignore-errors mismatch,negative,unused,inconsistent
           lcov --extract coverage-lcov/lcov.info \
             "$(pwd)/applications/*" "$(pwd)/rg_service/*" "$(pwd)/protobuf_utils/*" "$(pwd)/common/*" \
             --output-file coverage-lcov/lcov.info --rc branch_coverage=1 --ignore-errors unused
@@ -183,7 +187,7 @@ jobs:
             -ignore-filename-regex='.*/tests/.*|.*\.pb\.(h|cc)$|.*/vcpkg_installed/.*' \
             | tee coverage-llvm-cov/stdout.txt
 
-          clang --version | head -1 | awk '{print $3}' > /tmp/tool_version
+          clang --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 > /tmp/tool_version
           du -sk /tmp/profiles | awk '{print $1}' > /tmp/raw_kib
           du -sk coverage-llvm-cov/html | awk '{print $1}' > /tmp/html_kib
           echo "report_seconds=$(( $(date +%s) - report_start ))" >> "$GITHUB_ENV"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -136,18 +136,21 @@ jobs:
         run: |
           mkdir -p coverage-lcov
           report_start=$(date +%s)
-          # "inconsistent" is GCC 15's geninfo reporting a mismatched end line for TEST_F bodies
-          # (GoogleTest's macro expansion confuses gcov's line tracking, not a real data problem);
+          # "inconsistent" is GCC 15's geninfo reporting a mismatched end line, or a "not hit but
+          # line is" contradiction, for lambdas inside TEST_F bodies (GoogleTest's macro expansion
+          # confuses gcov's line tracking, not a real data problem). geninfo re-validates this on
+          # every pass (capture, extract, remove), so all three need the flag, not just the first.
           # "mismatch" is the same false positive geninfo already reports for libstdc++/libprotobuf
           # headers, unrelated to this project's own code.
           lcov --capture --directory build --output-file coverage-lcov/lcov.info \
             --rc branch_coverage=1 --ignore-errors mismatch,negative,unused,inconsistent
           lcov --extract coverage-lcov/lcov.info \
             "$(pwd)/applications/*" "$(pwd)/rg_service/*" "$(pwd)/protobuf_utils/*" "$(pwd)/common/*" \
-            --output-file coverage-lcov/lcov.info --rc branch_coverage=1 --ignore-errors unused
+            --output-file coverage-lcov/lcov.info --rc branch_coverage=1 --ignore-errors unused,inconsistent
           lcov --remove coverage-lcov/lcov.info '*/tests/*' '*.pb.h' '*.pb.cc' \
-            --output-file coverage-lcov/lcov.info --rc branch_coverage=1 --ignore-errors unused
-          genhtml coverage-lcov/lcov.info --output-directory coverage-lcov/html --branch-coverage
+            --output-file coverage-lcov/lcov.info --rc branch_coverage=1 --ignore-errors unused,inconsistent
+          genhtml coverage-lcov/lcov.info --output-directory coverage-lcov/html --branch-coverage \
+            --ignore-errors inconsistent
           lcov --summary coverage-lcov/lcov.info --rc branch_coverage=1 | tee coverage-lcov/stdout.txt
           lcov --version | grep -oE '[0-9]+\.[0-9]+' | head -1 > /tmp/tool_version
           find build -name '*.gcda' -o -name '*.gcno' | xargs du -ck 2>/dev/null | tail -1 | awk '{print $1}' \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    # "closed" doesn't need a build - it only runs cleanup-pages, removing this PR's published
+    # reports. The default types (opened, synchronize, reopened) are otherwise unchanged.
+    types: [opened, synchronize, reopened, closed]
   workflow_dispatch:
 
 permissions:
@@ -23,6 +26,7 @@ jobs:
   # formats are not cross-readable. See cmake/Coverage.cmake for why the two modes are compiler-bound.
   measure:
     name: measure (${{ matrix.tool }})
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     container:
       image: alpine:3.24
@@ -235,9 +239,13 @@ jobs:
   compare:
     name: compare tool reports
     needs: measure
-    if: always()
+    if: always() && github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # contents: write is only needed for the gh-pages push below; the rest of this job only reads.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v5
 
@@ -253,13 +261,55 @@ jobs:
       - name: Post to job summary
         run: cat comparison.md >> "$GITHUB_STEP_SUMMARY"
 
+      # Each tool's own HTML (gcovr's source-highlighted file tree, lcov's genhtml navigation,
+      # llvm-cov's instantiation-level view) is a real interactive report with its own CSS/JS - a
+      # Check Run summary is markdown-only and can't render it, and an Actions artifact needs a
+      # manual download instead of a click-through link. Three plain per-tool pages, kept as close
+      # to what each tool already generates as possible, published under this PR's own path so the
+      # links stay meaningful for this PR specifically instead of getting overwritten by whichever
+      # branch/PR built next. cleanup-pages below removes this path once the PR closes.
+      - name: Assemble per-PR coverage pages
+        if: github.event_name == 'pull_request'
+        run: |
+          pr=${{ github.event.pull_request.number }}
+          out="pages-out/pr-$pr"
+          mkdir -p "$out"
+          for tool in gcovr lcov llvm-cov; do
+            cp -r "reports/coverage-$tool/html" "$out/$tool"
+          done
+          cat > "$out/index.html" <<HTML
+          <!doctype html>
+          <title>Coverage - PR #$pr</title>
+          <h1>Coverage - PR #$pr</h1>
+          <ul>
+            <li><a href="gcovr/">gcovr</a></li>
+            <li><a href="lcov/">lcov</a></li>
+            <li><a href="llvm-cov/">llvm-cov</a></li>
+          </ul>
+          HTML
+
+      - name: Deploy per-PR coverage pages
+        if: github.event_name == 'pull_request'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: pages-out
+          # keep_files preserves every other open PR's own pr-<n>/ directory already on gh-pages;
+          # without it each deploy would wipe the branch down to just this PR's own output.
+          keep_files: true
+
       - name: Comment on pull request
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
-            const body = fs.readFileSync('comparison.md', 'utf8');
+            const pagesUrl = `https://${context.repo.owner}.github.io/${context.repo.repo}/pr-${context.issue.number}`;
+            const body = fs.readFileSync('comparison.md', 'utf8')
+              + `\n## Full reports (per tool)\n\n`
+              + `- [gcovr](${pagesUrl}/gcovr/)\n`
+              + `- [lcov](${pagesUrl}/lcov/)\n`
+              + `- [llvm-cov](${pagesUrl}/llvm-cov/)\n`;
             const marker = '<!-- coverage-tool-comparison -->';
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -283,3 +333,33 @@ jobs:
                 body: content,
               });
             }
+
+  cleanup-pages:
+    name: remove closed PR's coverage pages
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Remove this PR's coverage pages from gh-pages
+        run: |
+          pr=${{ github.event.pull_request.number }}
+          if ! git ls-remote --exit-code --heads origin gh-pages > /dev/null 2>&1; then
+            echo "gh-pages branch does not exist yet, nothing to clean up."
+            exit 0
+          fi
+          git fetch origin gh-pages:gh-pages
+          git worktree add /tmp/gh-pages gh-pages
+          cd /tmp/gh-pages
+          if [ -d "pr-$pr" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git rm -r --quiet "pr-$pr"
+            git commit -m "Remove coverage pages for closed PR #$pr"
+            git push origin gh-pages
+          else
+            echo "No coverage pages found for PR #$pr, nothing to remove."
+          fi

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,9 +5,6 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-    # "closed" doesn't need a build - it only runs cleanup-pages, removing this PR's published
-    # reports. The default types (opened, synchronize, reopened) are otherwise unchanged.
-    types: [opened, synchronize, reopened, closed]
   workflow_dispatch:
 
 permissions:
@@ -26,7 +23,6 @@ jobs:
   # formats are not cross-readable. See cmake/Coverage.cmake for why the two modes are compiler-bound.
   measure:
     name: measure (${{ matrix.tool }})
-    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     container:
       image: alpine:3.24
@@ -239,13 +235,9 @@ jobs:
   compare:
     name: compare tool reports
     needs: measure
-    if: always() && github.event.action != 'closed'
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # contents: write is only needed for the gh-pages push below; the rest of this job only reads.
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v5
 
@@ -261,55 +253,13 @@ jobs:
       - name: Post to job summary
         run: cat comparison.md >> "$GITHUB_STEP_SUMMARY"
 
-      # Each tool's own HTML (gcovr's source-highlighted file tree, lcov's genhtml navigation,
-      # llvm-cov's instantiation-level view) is a real interactive report with its own CSS/JS - a
-      # Check Run summary is markdown-only and can't render it, and an Actions artifact needs a
-      # manual download instead of a click-through link. Three plain per-tool pages, kept as close
-      # to what each tool already generates as possible, published under this PR's own path so the
-      # links stay meaningful for this PR specifically instead of getting overwritten by whichever
-      # branch/PR built next. cleanup-pages below removes this path once the PR closes.
-      - name: Assemble per-PR coverage pages
-        if: github.event_name == 'pull_request'
-        run: |
-          pr=${{ github.event.pull_request.number }}
-          out="pages-out/pr-$pr"
-          mkdir -p "$out"
-          for tool in gcovr lcov llvm-cov; do
-            cp -r "reports/coverage-$tool/html" "$out/$tool"
-          done
-          cat > "$out/index.html" <<HTML
-          <!doctype html>
-          <title>Coverage - PR #$pr</title>
-          <h1>Coverage - PR #$pr</h1>
-          <ul>
-            <li><a href="gcovr/">gcovr</a></li>
-            <li><a href="lcov/">lcov</a></li>
-            <li><a href="llvm-cov/">llvm-cov</a></li>
-          </ul>
-          HTML
-
-      - name: Deploy per-PR coverage pages
-        if: github.event_name == 'pull_request'
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: pages-out
-          # keep_files preserves every other open PR's own pr-<n>/ directory already on gh-pages;
-          # without it each deploy would wipe the branch down to just this PR's own output.
-          keep_files: true
-
       - name: Comment on pull request
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
-            const pagesUrl = `https://${context.repo.owner}.github.io/${context.repo.repo}/pr-${context.issue.number}`;
-            const body = fs.readFileSync('comparison.md', 'utf8')
-              + `\n## Full reports (per tool)\n\n`
-              + `- [gcovr](${pagesUrl}/gcovr/)\n`
-              + `- [lcov](${pagesUrl}/lcov/)\n`
-              + `- [llvm-cov](${pagesUrl}/llvm-cov/)\n`;
+            const body = fs.readFileSync('comparison.md', 'utf8');
             const marker = '<!-- coverage-tool-comparison -->';
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -333,33 +283,3 @@ jobs:
                 body: content,
               });
             }
-
-  cleanup-pages:
-    name: remove closed PR's coverage pages
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Remove this PR's coverage pages from gh-pages
-        run: |
-          pr=${{ github.event.pull_request.number }}
-          if ! git ls-remote --exit-code --heads origin gh-pages > /dev/null 2>&1; then
-            echo "gh-pages branch does not exist yet, nothing to clean up."
-            exit 0
-          fi
-          git fetch origin gh-pages:gh-pages
-          git worktree add /tmp/gh-pages gh-pages
-          cd /tmp/gh-pages
-          if [ -d "pr-$pr" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git rm -r --quiet "pr-$pr"
-            git commit -m "Remove coverage pages for closed PR #$pr"
-            git push origin gh-pages
-          else
-            echo "No coverage pages found for PR #$pr, nothing to remove."
-          fi

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,11 +38,15 @@ jobs:
           - tool: lcov
             cxx_compiler: g++
             coverage_mode: gcov
-            packages: g++ lcov
+            packages: g++ lcov gzip
           - tool: llvm-cov
             cxx_compiler: clang++
             coverage_mode: llvm
-            packages: clang compiler-rt llvm22
+            # gcc/binutils are not used to build this project's own code (CMAKE_CXX_COMPILER=clang++
+            # below), but vcpkg's own detect_compiler helper port, run while building EventLoop,
+            # needs a system `cc` to probe - matching ci.yml's clang matrix entries, which install
+            # the same pair for the same reason.
+            packages: clang compiler-rt llvm22 gcc binutils
     steps:
       - name: Install build dependencies
         run: |
@@ -106,7 +110,7 @@ jobs:
       - name: Generate gcovr report
         if: matrix.tool == 'gcovr'
         run: |
-          mkdir -p coverage-gcovr
+          mkdir -p coverage-gcovr/html
           report_start=$(date +%s)
           # --exclude-throw-branches is reported separately below, not applied to the primary
           # report: GCC's implicit exception-unwind branches have no llvm-cov counterpart, so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ include(ConfigureRPath)
 # Apply binary size optimizations for Release builds
 include(BuildOptimizations)
 
+# Apply coverage instrumentation when ENABLE_COVERAGE is set (must follow BuildOptimizations, which
+# it checks against)
+include(Coverage)
+
 # Configure and report the compiler launcher (ccache when available)
 include(CompilerLauncher)
 

--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 anderewrey
+
+# Coverage.cmake
+# Instruments the project for code coverage measurement.
+#
+# ENABLE_COVERAGE selects the instrumentation, not the report generator:
+#   OFF  - no instrumentation (default)
+#   gcov - GCC counters written to .gcno/.gcda, consumed by gcovr or by lcov/genhtml
+#   llvm - Clang source-based coverage mapping, consumed by llvm-profdata/llvm-cov
+#
+# The two modes are compiler-bound, because each one's counter format is only readable by the
+# matching toolchain: gcov requires GCC and llvm requires Clang. Clang can emit gcov-style counters
+# too, but their format version tracks Clang's own release rather than GCC's, which makes them a
+# frequent source of "unsupported .gcda version" failures in gcovr and lcov, so the mode rejects it.
+#
+# Report generation is deliberately not modelled here. Each tool needs a different post-processing
+# pipeline over the same instrumented build, and .github/workflows/coverage.yml drives them.
+
+set(ENABLE_COVERAGE "OFF" CACHE STRING "Code coverage instrumentation to build with: OFF, gcov, or llvm")
+set_property(CACHE ENABLE_COVERAGE PROPERTY STRINGS OFF gcov llvm)
+
+option(COVERAGE_MCDC "Add MC/DC instrumentation, ENABLE_COVERAGE=llvm only" ON)
+
+if(ENABLE_COVERAGE STREQUAL "OFF")
+    return()
+endif()
+
+# BuildOptimizations.cmake strips symbols (-s) and garbage-collects sections in these build types,
+# which discards the counter sections and the debug info that both formats need to map counters
+# back to source lines.
+if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+    message(FATAL_ERROR
+            "ENABLE_COVERAGE=${ENABLE_COVERAGE} is incompatible with CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}. "
+            "Use a Debug build for coverage.")
+endif()
+
+if(ENABLE_COVERAGE STREQUAL "gcov")
+    if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        message(FATAL_ERROR
+                "ENABLE_COVERAGE=gcov requires GCC, but CMAKE_CXX_COMPILER_ID is "
+                "${CMAKE_CXX_COMPILER_ID}. Use ENABLE_COVERAGE=llvm with Clang.")
+    endif()
+
+    # -fprofile-abs-path records the absolute source path in the .gcno, so gcov resolves sources no
+    # matter which directory the report generator runs from. Without it, the reactor headers are
+    # recorded relative to each test binary's object directory and get reported as unresolvable.
+    #
+    # -fprofile-update=atomic makes counter increments atomic. The reactor tests execute gRPC
+    # callbacks on the gRPC thread pool while the test body runs on its own thread, so the same
+    # counters in reactor_client.h are incremented concurrently, and the default non-atomic
+    # increment silently loses counts.
+    #
+    # -O0 is explicit because CMAKE_CXX_FLAGS_DEBUG only carries -g: at any higher level, inlining
+    # and basic-block reordering attribute counts to lines the code no longer executes in place.
+    add_compile_options(--coverage -fprofile-abs-path -fprofile-update=atomic -O0 -g)
+    add_link_options(--coverage)
+    message(STATUS "Coverage instrumentation enabled: gcov (GCC counters, .gcno/.gcda)")
+elseif(ENABLE_COVERAGE STREQUAL "llvm")
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        message(FATAL_ERROR
+                "ENABLE_COVERAGE=llvm requires Clang, but CMAKE_CXX_COMPILER_ID is "
+                "${CMAKE_CXX_COMPILER_ID}. Use ENABLE_COVERAGE=gcov with GCC.")
+    endif()
+
+    add_compile_options(-fprofile-instr-generate -fcoverage-mapping -O0 -g)
+    add_link_options(-fprofile-instr-generate)
+
+    # MC/DC (modified condition/decision coverage) instruments each condition of a compound
+    # decision independently, so it reports whether every condition was shown to independently
+    # affect the outcome. Clang skips, with a warning, any decision holding more than six
+    # conditions. It has no gcov equivalent, which is why it is a separate switch here.
+    if(COVERAGE_MCDC)
+        add_compile_options(-fcoverage-mcdc)
+        message(STATUS "Coverage instrumentation enabled: llvm (source-based mapping, with MC/DC)")
+    else()
+        message(STATUS "Coverage instrumentation enabled: llvm (source-based mapping)")
+    endif()
+else()
+    message(FATAL_ERROR "ENABLE_COVERAGE must be OFF, gcov, or llvm, but is '${ENABLE_COVERAGE}'.")
+endif()


### PR DESCRIPTION
## Summary

- Adds `ENABLE_COVERAGE=gcov|llvm` to `cmake/Coverage.cmake`, instrumenting a Debug build for either
  GCC's `.gcno`/`.gcda` counters or Clang's source-based coverage mapping. The two modes are
  compiler-bound because the counter formats are not cross-readable.
- Adds `.github/workflows/coverage.yml`: a 3-way matrix job runs the full test suite once per tool
  (gcovr and lcov share one gcc-debug build; llvm-cov gets its own clang build, since it needs the
  Clang-specific instrumentation), then a `compare` job downloads all three reports and diffs them
  per file via `.github/scripts/compare-coverage.py`, posted to the job summary and as a PR comment.

## Why measure all three instead of picking one upfront

Doc-level reasoning about "which coverage tool is best for this project" is guesswork until the
actual numbers are in front of us. This workflow runs gcovr, lcov, and llvm-cov against the
identical test suite and reports line/branch/function/region coverage side by side, plus build,
report-generation time, and artifact size, so the follow-up decision (which tool, or tools, to keep
wired into CI permanently) is based on this repo's real numbers, not general tool comparisons.

## Test plan

- [x] Local sanity build: `-DENABLE_COVERAGE=gcov` with GCC 14 configures, builds, and all 34
      existing tests pass under `ctest`.
- [x] Local sanity check: `gcovr` (8.6, matching the Alpine 3.24 `community` package) against that
      build produces a non-empty summary with the intended filters (`applications/`, `rg_service/`,
      `protobuf_utils/`, `common/`, excluding `tests/` and generated `.pb.{h,cc}`).
- [x] `compare-coverage.py` smoke-tested against that real gcovr summary; produces the expected
      totals/per-file markdown tables.
- [x] `pre-commit run` clean on `cmake/Coverage.cmake`, `CMakeLists.txt`, `coverage.yml`.
- [ ] CI run on this PR: confirms all three tool jobs succeed on `alpine:3.24` (package versions
      pre-verified against the APKINDEX: `lcov 2.3.1-r1`, `gcovr 8.6-r1`, `llvm22 22.1.3-r0`, `clang
      22.1.3-r2`/`compiler-rt 22.1.3-r0`) and produces a real cross-tool comparison to review.