### PR TITLE
Don't re-run static-analysis on master pushes, only on the PR that lands there

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,7 +1,13 @@
 name: static-analysis
 
 on:
+  # Excludes master: a PR targeting master already ran this via pull_request below before merge, so
+  # a push straight to master (post-merge) would be a redundant re-run - and it collides with ci.yml's
+  # own push-triggered run for the same commit, racing to create the "JUnit Test Report" check run
+  # (mikepenz/action-junit-report's Checks API call has no explicit check-suite target, so GitHub can
+  # attach it to whichever of the two same-commit check suites it treats as current).
   push:
+    branches-ignore: [master]
   pull_request:
     branches: [master]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- After merging #20, the "JUnit Test Report" check run (created by `ci.yml`'s `gcc-debug` job via `mikepenz/action-junit-report`) showed up under the `static-analysis` workflow instead of `ci`.
- Root cause: `static-analysis.yml`'s `push:` trigger had no branch filter, so it re-ran on the post-merge push to `master` at the same moment as `ci.yml`'s own push-triggered run for that commit. With two workflow runs live on the same SHA, GitHub attached the check run (created via the Checks API with no explicit check-suite target) to the wrong one.
- Fix: scope `static-analysis.yml`'s `push:` trigger to `branches-ignore: [master]`. A PR targeting master already runs `static-analysis` via its `pull_request` trigger before merge, so the post-merge push re-run was redundant on top of causing the collision.

## Test plan

- [ ] Confirm `static-analysis` no longer fires on a direct push to `master` (only on `pull_request` and `workflow_dispatch`)
- [ ] Confirm `ci`'s "JUnit Test Report" check run lands under the `ci` workflow after this merges


---
_Generated by [Claude Code](https://claude.ai/code/session_01Amkw5L39AeCeooSm4BSy3G)_